### PR TITLE
test against 0.4 and 0.5 separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.build("Complementarity"); Pkg.test("Complementarity", coverage=true)'
+#script: # use the default script which is equivalent to the following
+#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#    - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.build("Complementarity"); Pkg.test("Complementarity", coverage=true)'
 after_success:
     - echo $TRAVIS_JULIA_VERSION
     - julia -e 'cd(Pkg.dir("Complementarity")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
`release` will change meaning soon, so add 0.4 explicitly to continue testing there
0.5 currently means the most recent RC, and will mean the latest point release once final is out
