### PR TITLE
Update JuMP and MathOptInterface deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 JuMP = "0.22"
-PATHSolver = "1.1"
+PATHSolver = "1.2"
 NLsolve = "4"
 MathOptInterface = "0.10"
 julia = "1.3, 2"

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,10 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-JuMP = "0.21"
+JuMP = "0.22"
 PATHSolver = "1.1"
 NLsolve = "4"
-MathOptInterface = "0.9"
+MathOptInterface = "0.10"
 julia = "1.3, 2"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ JuMP = "0.22"
 PATHSolver = "1.2"
 NLsolve = "4"
 MathOptInterface = "0.10"
-julia = "1.3, 2"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
~This first requires https://github.com/chkwon/PATHSolver.jl/issues/60 to be resolved, but then it all seems to work.~

Should be ready now. I also removed a compat entry that declared this as working with Julia 2.0. I believe packages shouldn't do that at this stage, as they aren't known to work with Julia 2.0 :)