### PR TITLE
Update mcp.jl

### DIFF
--- a/src/mcp.jl
+++ b/src/mcp.jl
@@ -141,8 +141,9 @@ function _solve_path!(m::JuMP.Model; kwargs...)
         MOI.eval_constraint_jacobian(d, jac_val, z)
         # return matrix also should be in RawIndex
         # since it is the order in which constraints are added
-
-        Jac = sparse(I, J, jac_val)  # SparseMatrixCSC
+        
+        nc = length(d.constraints)           # number of constraints
+        Jac = sparse(I, J, jac_val, nc, nc)  # SparseMatrixCSC
         return Jac
     end
 


### PR DESCRIPTION
Came across a weird bug when helping a friend who has very little experience on Julia or complementarity modelling. If for some reason, the last variable defined in the model does not appear in any of the complementarity expressions/mappings, that will cause a bug with the sparse Jacobian where the dimensions of that matrix become smaller than the number of constraints. This will then lead to a BoundsError later in the code. A similar bug would happen if the last complementarity constraint had a constant value for the expression/mapping. My proposed fix is to force the correct dimensions for the sparse Jacobian matrix.

Minimal working example modified from the README example:
```
using Complementarity, JuMP

m = MCPModel()

@variable(m, x >= 0)
@variable(m, y >= 0)

@mapping(m, F1, x+2)
@mapping(m, F2, 2)

@complementarity(m, F1, x)
@complementarity(m, F2, y)

status = solveMCP(m)

@show result_value(x)
@show result_value(y)
```