### PR TITLE
Ignore equations complementary to fixed variables in Jacobian

### DIFF
--- a/src/mcp.jl
+++ b/src/mcp.jl
@@ -258,6 +258,14 @@ function _solve_path!(m::JuMP.Model; kwargs...)
     n = length(p)
 
 
+ 
+    if n == 0
+        #If all the variables are fixed, there is nothing to solve
+        return return_type[1]
+    end
+
+
+
     JuMP.@NLconstraint(m, [i=1:n], mcp_data[p[i]].F == 0)
     #JuMP.@NLconstraint(m, [i=1:n], mcp_data[conversion_dict[p[i]]].F == 0)
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using Complementarity
 
+
 @testset "Complementarity Tests" begin
 
     include("../examples/mcp/transmcp.jl")


### PR DESCRIPTION
This update proposes two major changes:

1. Ignore any fixed variables in the Jacobian to reduce computation time
2. Add complementarity conditions by equations rather than variable to account for filtered equation conditions.

The motivation for the first change comes from the complementarity conditions. Specifically, if $x$ is a variable and $Y$ is an equation complementary to $x$, so $x\cdot Y=0$. If we fix $x\neq0$, then $Y$ must equal 0. Currently, this condition is added to the Jacobian increasing size and computation time. 

To solve this is, essentially, a filter and match problem. Filter out conditions with fixed variables and then match indices to the Jacobian so things work out. I've done this by adding several functions specializing in non_fixed variables. 

The second change allows one to define an equation on a subset of a variable and not raise an error. This is particularly useful when a variable is defined on over a set, $A = B \cup F$, where all the variables $x[F]$ will be fixed. Then you can define an equation as: $Y[b = A; b \notin F]$, in reality we may not know $B$ and $F$, but rather they'll correspond to 0 values in some dataset. 

[I posted this question](https://discourse.julialang.org/t/key-error-when-adding-a-complementarity-condition/87810) on discourse that was the instigation for these changes. As stated, I'm working on some converting some economic models from GAMs to Julia and these are features that GAMs does natively. 

I am new to Julia so my code may be rather non-Julia-ish. My primary language is Python, which may explain some of the code. 

I've mentioned these changes to @davidanthoff.

